### PR TITLE
Update era-skos-safetyEventTypes.ttl

### DIFF
--- a/iss-skos/era-skos-safetyEventTypes.ttl
+++ b/iss-skos/era-skos-safetyEventTypes.ttl
@@ -37,7 +37,7 @@ iss-set:SafetyEventTypes a skos:ConceptScheme ;
 #################################################################
 
 
-iss-set:CategoryAEvents
+iss-set:CategoryAEvent
         rdf:type        skos:Concept ;         skos:inScheme iss-set:SafetyEventTypes;         skos:topConceptOf iss-set:SafetyEventTypes;
         skos:prefLabel  "Category A Event" .
         


### PR DESCRIPTION
remove 's' in one category to be consistent with the rest